### PR TITLE
add current_cover_position to wink covers

### DIFF
--- a/homeassistant/components/cover/wink.py
+++ b/homeassistant/components/cover/wink.py
@@ -64,3 +64,8 @@ class WinkCoverDevice(WinkDevice, CoverDevice):
             return False
         else:
             return None
+
+    @property
+    def current_cover_position(self):
+        """Return current position of cover."""
+        return 0 if self.is_closed else 100


### PR DESCRIPTION
**Description:**
Add the current postion property to wink covers to show the current postion of the cover.

This enables the open /close icons and also disables the appropriate control buttons.
